### PR TITLE
Release v0.5 — 하네스 개선 P1 (페이지 검증 + 백로그 lint 트리거)

### DIFF
--- a/.claude/skills/wiki-ingest/SKILL.md
+++ b/.claude/skills/wiki-ingest/SKILL.md
@@ -13,6 +13,8 @@ description: How to ingest a raw source into the LLM wiki (v2.1 lazy) — write 
 
 규약 정본: `CLAUDE.md`.
 
+> **주의:** 페이지 파일에 `</content>` 같은 **닫는 태그·래퍼를 절대 붙이지 마라.** 파일은 순수 마크다운(frontmatter + 본문)으로 끝난다. (과거 인제스트가 EOF에 stray `</content>`를 남겨 85개 파일을 sweep한 적 있음.)
+
 ## 절차
 
 1. **소스 읽기 + 중복 체크.** `raw/` 대상. **본문 immutable.** frontmatter `ingest_status: done`이면 이미 인제스트 — 사용자에게 알리고 중단(재인제스트는 갱신 모드 별도). 소스 유형 판별(official/code/normal/verbal).

--- a/.claude/skills/wiki-lint/SKILL.md
+++ b/.claude/skills/wiki-lint/SKILL.md
@@ -10,6 +10,9 @@ description: How to health-check the LLM wiki (v2) — run link-audit + decay sc
 ## 1단계: 결정적 검사 (스크립트 — LLM 토큰 0)
 
 ```bash
+# 페이지 포맷 검증: stray 태그·frontmatter·type·confidence 형식 (무성 오염 조기 차단)
+python3 .claude/skills/wiki-lint/scripts/validate-pages.py . --json
+#   → stray-tag/no-frontmatter/no-type/bad-confidence 위반 발견 시 먼저 정리
 # 링크: 끊긴 wikilink + 고아 + 누락 타겟 집계 (L3/L4/moc 대상)
 python3 .claude/skills/wiki-lint/scripts/link-audit.py . --json
 #   broken       : 대상 없는 wikilink (page,target 중복 제거)

--- a/.claude/skills/wiki-lint/scripts/lint-due.sh
+++ b/.claude/skills/wiki-lint/scripts/lint-due.sh
@@ -21,18 +21,33 @@ if [ -d "$root/wiki/L1-working" ]; then
   l1=$(find "$root/wiki/L1-working" -name '*.md' -type f 2>/dev/null | wc -l | tr -d ' ')
 fi
 
+# ingests since the last lint (backlog of deferred merges). Reset on each lint;
+# final count = ingests after the last lint (or all ingests if never linted).
+backlog=0
+if [ -f "$log" ]; then
+  # 날짜 헤딩만 매칭 (last 추출과 동일한 엄격도 — [draft] 같은 비날짜 헤딩 오카운트 방지)
+  backlog=$(awk '/^## \[[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]\] lint/{c=0; next} /^## \[[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]\] ingest/{c++} END{print c+0}' "$log")
+fi
+
 if [ -z "$last" ]; then
   echo "NEVER"
   echo "L1:$l1"
+  echo "BACKLOG:$backlog"
   exit 0
 fi
 
 # days between last lint and today (portable: python3 for date math)
 days=$(python3 - "$last" <<'PY'
-import sys; from datetime import date
-last=date.fromisoformat(sys.argv[1]); print((date.today()-last).days)
+import sys
+from datetime import date
+try:
+    last = date.fromisoformat(sys.argv[1]); print((date.today() - last).days)
+except Exception:
+    print("")   # 파싱 실패 시 빈 값 → 아래에서 0으로 방어
 PY
 )
+# days가 비었거나 숫자 아니면 0으로 (정수 비교 crash·set -u 중단 방지)
+case "$days" in ''|*[!0-9]*) days=0 ;; esac
 
 if [ "$days" -gt "$thresh" ]; then
   echo "DUE $days"
@@ -40,3 +55,4 @@ else
   echo "OK $days"
 fi
 echo "L1:$l1"
+echo "BACKLOG:$backlog"

--- a/.claude/skills/wiki-lint/scripts/validate-pages.py
+++ b/.claude/skills/wiki-lint/scripts/validate-pages.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""페이지 포맷 검증 (deterministic — 0 LLM 토큰).
+
+무성 오염을 조기에 잡는다. 과거 인제스터가 EOF에 stray `</content>`·`</invoke>`를
+남긴 사태를 계기로 추가. lint/SessionStart에서 싸게 돌린다.
+
+검사 항목:
+  [stray-tag]   본문에 홀로 선 닫는 태그 (</content> 등) — 인제스트 아티팩트
+                (코드펜스 ``` 안·frontmatter 안은 제외 — 예시 태그 오탐 방지)
+  [no-frontmatter] wiki 페이지인데 맨 앞이 `---` 아님
+  [no-type]     frontmatter에 `type:` 없음
+  [bad-confidence] confidence 값이 0.0~1.0 float 아님 (따옴표 허용)
+  [bad-source_kind] source_kind가 official|code|normal|verbal 아님 (따옴표 허용)
+
+범위: wiki/**.md(포맷+stray) + 루트 index.md/log.md(포맷+stray) + raw/**.md(stray만).
+Usage: validate-pages.py [vault_root] [--json]
+종료코드: 위반 있으면 1, 없으면 0.
+"""
+import os, re, sys, json
+
+STRAY_TAG = re.compile(r"^\s*</[a-zA-Z][^>]*>\s*$")
+FENCE = re.compile(r"^\s*(```|~~~)")
+KINDS = {"official", "code", "normal", "verbal"}
+
+
+def read_lines(path):
+    # utf-8-sig: UTF-8 BOM 있으면 벗겨서 읽음 (Windows 저장 파일 대응)
+    with open(path, encoding="utf-8-sig") as fh:
+        return fh.readlines()
+
+
+def split_frontmatter(lines):
+    """(has_fm, fm_text, body_start_index). 첫 --- ... --- 블록."""
+    if not lines or lines[0].strip() != "---":
+        return False, "", 0
+    fm = []
+    for i, l in enumerate(lines[1:], start=1):
+        if l.strip() == "---":
+            return True, "".join(fm), i + 1
+        fm.append(l)
+    return False, "", 0  # 안 닫힘 → frontmatter 없음 취급
+
+
+def unquote(v):
+    v = v.strip()
+    if len(v) >= 2 and v[0] == v[-1] and v[0] in "\"'":
+        return v[1:-1]
+    return v
+
+
+def fm_field(fm, key):
+    m = re.search(rf"^{key}:\s*(.+)$", fm, re.MULTILINE)
+    return unquote(m.group(1)) if m else None
+
+
+def stray_tags(lines, body_start):
+    """코드펜스·frontmatter 밖의 홀로 선 닫는 태그 줄 번호 목록."""
+    out, in_fence = [], False
+    for i, l in enumerate(lines, 1):
+        if i <= body_start:          # frontmatter 영역 건너뜀
+            continue
+        if FENCE.match(l):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        if STRAY_TAG.match(l):
+            out.append((i, l.strip()))
+    return out
+
+
+def check_page(rel, path, issues, page_checks):
+    lines = read_lines(path)
+    has_fm, fm, body_start = split_frontmatter(lines)
+    for ln, detail in stray_tags(lines, body_start):
+        issues.append({"file": rel, "line": ln, "kind": "stray-tag", "detail": detail})
+    if not page_checks:
+        return
+    if not has_fm:
+        issues.append({"file": rel, "line": 1, "kind": "no-frontmatter", "detail": ""})
+        return
+    if not re.search(r"^type:\s*\S", fm, re.MULTILINE):
+        issues.append({"file": rel, "line": 1, "kind": "no-type", "detail": ""})
+    conf = fm_field(fm, "confidence")
+    if conf is not None:
+        try:
+            v = float(conf)
+            if not (0.0 <= v <= 1.0):
+                raise ValueError
+        except ValueError:
+            issues.append({"file": rel, "line": 1, "kind": "bad-confidence", "detail": conf})
+    sk = fm_field(fm, "source_kind")
+    if sk is not None and sk not in KINDS:
+        issues.append({"file": rel, "line": 1, "kind": "bad-source_kind", "detail": sk})
+
+
+def main():
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    as_json = "--json" in sys.argv[1:]
+    root = args[0] if args else "."
+    issues = []
+
+    for dp, _, files in os.walk(os.path.join(root, "wiki")):
+        for f in files:
+            if f.endswith(".md"):
+                p = os.path.join(dp, f)
+                check_page(os.path.relpath(p, root), p, issues, page_checks=True)
+    for f in ("index.md", "log.md"):
+        p = os.path.join(root, f)
+        if os.path.isfile(p):
+            check_page(f, p, issues, page_checks=True)
+    for dp, _, files in os.walk(os.path.join(root, "raw")):
+        for f in files:
+            if f.endswith(".md"):
+                p = os.path.join(dp, f)
+                check_page(os.path.relpath(p, root), p, issues, page_checks=False)
+
+    by_kind = {}
+    for it in issues:
+        by_kind[it["kind"]] = by_kind.get(it["kind"], 0) + 1
+
+    if as_json:
+        print(json.dumps({"issue_count": len(issues), "by_kind": by_kind, "issues": issues},
+                         ensure_ascii=False, indent=2))
+    else:
+        if not issues:
+            print("OK — 포맷 위반 없음")
+        else:
+            print(f"위반 {len(issues)}건: " + ", ".join(f"{k}×{v}" for k, v in sorted(by_kind.items())))
+            for it in issues[:50]:
+                print(f"  [{it['kind']}] {it['file']}:{it['line']}  {it['detail']}")
+            if len(issues) > 50:
+                print(f"  … 외 {len(issues)-50}건")
+    sys.exit(1 if issues else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/wiki-lint/scripts/wiki-status-check.sh
+++ b/.claude/skills/wiki-lint/scripts/wiki-status-check.sh
@@ -8,16 +8,24 @@ here="$(cd "$(dirname "$0")" && pwd)"
 root="$here/../../../.."   # scripts -> wiki-lint -> skills -> .claude -> vault root
 root="$(cd "$root" && pwd)"
 
+BACKLOG_THRESH=5   # 마지막 lint 이후 인제스트가 이만큼 쌓이면 lint 권고
+
 due_out="$(bash "$here/lint-due.sh" "$root" 3 2>/dev/null || true)"
 status_line="$(printf '%s\n' "$due_out" | head -1)"
 l1_line="$(printf '%s\n' "$due_out" | grep -E '^L1:' || echo 'L1:0')"
 l1="${l1_line#L1:}"
+backlog_line="$(printf '%s\n' "$due_out" | grep -E '^BACKLOG:' || echo 'BACKLOG:0')"
+backlog="${backlog_line#BACKLOG:}"
 
 msgs=()
 case "$status_line" in
   DUE*) days="${status_line#DUE }"; msgs+=("마지막 위키 lint로부터 ${days}일 경과 — \`wiki-ops\`로 lint 권장(망각·신뢰도·통합 점검).") ;;
   NEVER) : ;;  # fresh vault, no lint yet — stay quiet
 esac
+# 백로그 기반 lint 권고 (시간과 별개 — lazy가 미룬 병합이 쌓임)
+if [ "${backlog:-0}" -ge "$BACKLOG_THRESH" ]; then
+  msgs+=("마지막 lint 이후 인제스트 ${backlog}건 — 병합·신뢰도·관계가 밀려 있음. \`wiki-ops\`로 lint 배치 권장.")
+fi
 if [ "${l1:-0}" -gt 0 ]; then
   msgs+=("L1-working에 미압축 페이지 ${l1}장 — 세션 마무리 시 \`wiki-consolidate\`로 L1→L2 압축 권장.")
 fi
@@ -26,6 +34,13 @@ fi
 pending="$(bash "$here/ingest-status.sh" "$root" 2>/dev/null | grep -oE 'pending: [0-9]+' | grep -oE '[0-9]+' || echo 0)"
 if [ "${pending:-0}" -gt 0 ]; then
   msgs+=("raw/에 미인제스트 소스 ${pending}개 — \`wiki-ops\`로 인제스트 권장.")
+fi
+
+# 페이지 포맷 오염 (stray 태그·frontmatter 결함 등) — 조기 경보
+fmt_issues="$(python3 "$here/validate-pages.py" "$root" --json 2>/dev/null | grep -oE '"issue_count": *[0-9]+' | grep -oE '[0-9]+' | head -1)"
+fmt_issues="${fmt_issues:-0}"
+if [ "${fmt_issues:-0}" -gt 0 ]; then
+  msgs+=("페이지 포맷 위반 ${fmt_issues}건 감지(stray 태그·frontmatter 등) — \`validate-pages.py\`로 확인 후 정리 권장.")
 fi
 
 if [ "${#msgs[@]}" -eq 0 ]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,3 +88,4 @@ Ebbinghaus: 보존율 R=exp(−Δt/S), `decay_class`가 S 결정(아키텍처 �
 | 2026-07-23 | raw ingest 스탬프 | raw 본문/스탬프 정책 + wiki-ingest/ingestor + ingest-status.sh + SessionStart | 인제스트 완료 표시 요구 → 본문 immutable 유지하며 상태 frontmatter만 스탬프, 미인제스트 조회 |
 | 2026-07-23 | 비용 원장 | metrics/ingest-cost.csv + cost-report.py + wiki-ops 배선 | v2 비용대비효과 측정 — 문서당 토큰·페이지·낭비율 추적(오케스트레이터가 <usage> 기록) |
 | 2026-07-23 | v2.1 인제스트 최적화 | wiki-ingest(lazy)·wiki-ingestor(sonnet)·concept-index.sh·wiki-consolidate(배치병합)·cost-report(모델가중) | 속도·토큰 개선 — ①sonnet 라우팅 ②no-scan(concept-index) ③lazy(병합·신뢰도·관계·승격을 lint 배치로 지연). 측정: 페이지당 실질비용 ~4.6x↓·지연 ~3x↓ |
+| 2026-07-27 | 하네스 개선 P1 | validate-pages.py(포맷 검증)·lint-due(BACKLOG)·wiki-status-check | 무성 오염 조기 차단(stray 태그 85+3파일 sweep) + 백로그 기반 lint 트리거(시간 아닌 인제스트 누적 기준) |


### PR DESCRIPTION
## 개요
LLM-wiki 하네스 v0.5. 로그·통계 회고에서 도출한 **P1 개선 2건** 배선.

## 변경
- **페이지 포맷 검증** (`validate-pages.py` 신규) — stray 닫는태그·frontmatter·type·confidence·source_kind를 결정적으로 검사(토큰 0). 코드펜스/frontmatter 제외, 따옴표값·UTF-8 BOM 대응. → 무성 오염 조기 차단.
- **백로그 기반 lint 트리거** — `lint-due.sh`가 마지막 lint 이후 인제스트 수(BACKLOG) 출력, `wiki-status-check.sh`(SessionStart)가 5건+ 시 lint 권고. 시간이 아닌 **백로그 크기** 기준으로 lazy 인제스트 품질 실현 보장.
- 부수: wiki-lint 스킬에 validate 연동, wiki-ingest 스킬에 닫는태그 금지 가드.

## 배경
- `</content>`·`</invoke>` stray 태그가 88개 파일에 무성 누적 → 검증 부재가 원인. validate-pages.py로 재발 차단.
- 인제스트 27 : 린트 3 → 백로그가 시간 트리거만으론 안 잡힘 → 백로그 카운터 추가.

## 외부 리뷰
agy(외부 독립 AI) 2라운드: 초기 6건 지적(HIGH 2·MED 2·LOW 2) → 전부 수정 → 재검토 **VERDICT: CLEAN**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)