### PR TITLE
Release v0.6 — 하네스 개선 P2·P3 (비용/품질 규칙 + 완결성 자동화)

### DIFF
--- a/.claude/skills/wiki-ingest/SKILL.md
+++ b/.claude/skills/wiki-ingest/SKILL.md
@@ -51,7 +51,7 @@ description: How to ingest a raw source into the LLM wiki (v2.1 lazy) — write 
    ```
    본문은 한국어 골격(요약 + 핵심 몇 줄) + 관련 `[[ ]]` 링크 몇 개. **관계 `## 관계` 구조화는 생략**(lint 배치). **기존 개념과 겹치면 새로 만들지도, 기존을 열지도 마라** — claim::만 남기면 lint가 병합한다.
 
-5. **MoC 편입(가볍게).** 신규 L3만 알맞은 기존 MoC에 한 줄 추가. 새 주제 영역이면 MoC 1개 생성. 깊은 큐레이션은 `wiki-cartographer`/lint 몫.
+5. **MoC 편입(가볍게, 남발 금지).** 신규 L3는 **기존 MoC 우선** 편입(한 줄 추가). 새 MoC는 **정말 새 주제 영역이고 편입 페이지 ≥2일 때만** 생성 — 1페이지짜리 얇은 MoC는 만들지 말고 인접 기존 MoC나 `home-moc`의 "미분류" 섹션에 임시 배치. 깊은 큐레이션·MoC 재구성은 `wiki-cartographer`/lint 몫(MoC가 12개 넘으면 자동 권고).
 
 6. **index.md + log.md + raw 스탬프.**
    - index: 신규 페이지만 추가.

--- a/.claude/skills/wiki-ingest/scripts/concept-index.sh
+++ b/.claude/skills/wiki-ingest/scripts/concept-index.sh
@@ -1,21 +1,49 @@
 #!/usr/bin/env bash
 # Compact catalog of existing L3/L4 concepts — 병합 후보 판별용 (deterministic, 0 토큰).
-# 인제스트 시 45개 페이지 본문을 Read하지 말고 이 한 줄 출력만 보고 신규/기존을 가른다.
+# 인제스트 시 페이지 본문을 Read하지 말고 이 한 줄 출력만 보고 신규/기존을 가른다.
 # 각 줄: slug | title | aliases | confidence   (frontmatter만 읽음)
-# Usage: concept-index.sh [vault_root]   (default: .)
+#
+# Usage: concept-index.sh [vault_root] [filter ...]
+#   filter: (선택) 하나 이상의 키워드. 주면 slug|title|aliases에 그 키워드가
+#           (대소문자 무시) 포함된 줄만 출력 — 위키가 커질 때 카탈로그를 바운드.
+#           예) concept-index.sh . rag vector   → rag/vector 관련 개념만.
+#   필터 없으면 전체 출력. 끝에 요약 라인(총 N개 / 필터 매칭 M개)을 stderr로.
 set -uo pipefail
 root="${1:-.}"
-for dir in wiki/L3-semantic wiki/L4-procedural; do
-  d="$root/$dir"
-  [ -d "$d" ] || continue
-  for f in "$d"/*.md; do
-    [ -e "$f" ] || continue
-    slug="$(basename "$f" .md)"
-    # frontmatter 영역만 스캔 (첫 --- ... --- 블록)
-    fm="$(awk 'NR==1&&$0!="---"{exit} NR>1&&$0=="---"{exit} {print}' "$f")"
-    title="$(printf '%s\n' "$fm" | sed -n 's/^title:[[:space:]]*//p' | head -1)"
-    aliases="$(printf '%s\n' "$fm" | sed -n 's/^aliases:[[:space:]]*//p' | head -1)"
-    conf="$(printf '%s\n' "$fm" | sed -n 's/^confidence:[[:space:]]*//p' | head -1)"
-    printf '%s | %s | %s | %s\n' "$slug" "${title:-?}" "${aliases:-[]}" "${conf:-?}"
+shift || true
+filters=("$@")
+
+emit() {
+  for dir in wiki/L3-semantic wiki/L4-procedural; do
+    d="$root/$dir"
+    [ -d "$d" ] || continue
+    for f in "$d"/*.md; do
+      [ -e "$f" ] || continue
+      slug="$(basename "$f" .md)"
+      fm="$(awk 'NR==1&&$0!="---"{exit} NR>1&&$0=="---"{exit} {print}' "$f")"
+      title="$(printf '%s\n' "$fm" | sed -n 's/^title:[[:space:]]*//p' | head -1)"
+      aliases="$(printf '%s\n' "$fm" | sed -n 's/^aliases:[[:space:]]*//p' | head -1)"
+      conf="$(printf '%s\n' "$fm" | sed -n 's/^confidence:[[:space:]]*//p' | head -1)"
+      printf '%s | %s | %s | %s\n' "$slug" "${title:-?}" "${aliases:-[]}" "${conf:-?}"
+    done
   done
-done
+}
+
+total=0 shown=0
+while IFS= read -r line; do
+  total=$((total+1))
+  if [ "${#filters[@]}" -eq 0 ]; then
+    printf '%s\n' "$line"; shown=$((shown+1)); continue
+  fi
+  for kw in "${filters[@]}"; do
+    if printf '%s' "$line" | grep -qFi -- "$kw"; then   # -F: 고정 문자열(정규식 특수문자 c++·node.js·[RAG] 안전)
+      printf '%s\n' "$line"; shown=$((shown+1)); break
+    fi
+  done
+done < <(emit)
+
+if [ "${#filters[@]}" -eq 0 ]; then
+  echo "[concept-index] 총 ${total}개" >&2
+else
+  echo "[concept-index] 총 ${total}개 중 필터(${filters[*]}) 매칭 ${shown}개" >&2
+fi

--- a/.claude/skills/wiki-lint/SKILL.md
+++ b/.claude/skills/wiki-lint/SKILL.md
@@ -57,5 +57,10 @@ bash .claude/skills/wiki-lint/scripts/search.sh "<query>"
 
 조사할 새 질문·찾을 새 소스도 제안. 수리 반영 시 `updated`·해당되면 `last_confirmed` 갱신, log에 `## [오늘] lint | <요지>` append(자동화 훅이 이 항목으로 경과일 계산 — 반드시 남긴다).
 
+## 7단계: 후속 액션 (P3 — 지적이 실행으로)
+lint이 반복 지적만 하고 아무도 안 고치는 것을 막는다:
+- **고inbound 스텁 자동초안 제안.** `stub_targets` 중 **inbound ≥3**(여러 페이지가 가리킴)은 작성 가치가 확실 → 사용자에게 "이 스텁들 초안 만들까?" 제안하고, 승인 시 `wiki-ingestor`(또는 직접)로 골격 페이지 생성. (예: bert·gpt·llm·rnn — 3회 연속 lint에서 방치됐던 것)
+- **미해결 항목 → 확인 큐.** 사람 판단이 필요한 것(동일성 미확인 예: firstpick↔recruitment, 상충 우열 불명)은 lint가 임의 판정하지 말고 `_workspace/needs-confirm.md`에 `- [ ] <항목> (근거·필요한 확인)`으로 적재. SessionStart가 리마인드하고, 해소되면 체크. (표류 방지)
+
 ## 원칙
 **제안 먼저, 자동 수정 금지.** 삭제·병합·강등·대규모 재작성은 승인 후. 안전 수정(짝 링크 추가, 신뢰도 숫자 교정, last_confirmed 리셋)만 승인받아 적용. 스크립트가 링크·망각·신뢰도를 공짜로 계산하니, LLM 예산은 의미 검사(모순·승격 동치 판단)에 쓴다.

--- a/.claude/skills/wiki-lint/scripts/wiki-status-check.sh
+++ b/.claude/skills/wiki-lint/scripts/wiki-status-check.sh
@@ -9,6 +9,7 @@ root="$here/../../../.."   # scripts -> wiki-lint -> skills -> .claude -> vault 
 root="$(cd "$root" && pwd)"
 
 BACKLOG_THRESH=5   # 마지막 lint 이후 인제스트가 이만큼 쌓이면 lint 권고
+MOC_THRESH=12      # 주제 MoC(home 제외)가 이만큼 넘으면 cartographer 재구성 권고
 
 due_out="$(bash "$here/lint-due.sh" "$root" 3 2>/dev/null || true)"
 status_line="$(printf '%s\n' "$due_out" | head -1)"
@@ -41,6 +42,26 @@ fmt_issues="$(python3 "$here/validate-pages.py" "$root" --json 2>/dev/null | gre
 fmt_issues="${fmt_issues:-0}"
 if [ "${fmt_issues:-0}" -gt 0 ]; then
   msgs+=("페이지 포맷 위반 ${fmt_issues}건 감지(stray 태그·frontmatter 등) — \`validate-pages.py\`로 확인 후 정리 권장.")
+fi
+
+# MoC 남발 — home 제외 주제 MoC 수가 임계 넘으면 cartographer 재구성 권고
+moc_dir="$root/wiki/moc"
+if [ -d "$moc_dir" ]; then
+  moc_n=$(find "$moc_dir" -maxdepth 1 -name '*.md' -not -name 'home-moc.md' 2>/dev/null | wc -l | tr -d ' ')
+  if [ "${moc_n:-0}" -gt "$MOC_THRESH" ]; then
+    msgs+=("주제 MoC ${moc_n}개 — home-moc 비대·얇은 MoC 가능. \`wiki-cartographer\`로 그룹 재구성 검토 권장.")
+  fi
+fi
+
+# 미해결 확인 큐 — 사람 판단이 필요한 항목(동일성·상충 등)이 쌓였으면 리마인드
+ncq="$root/_workspace/needs-confirm.md"
+if [ -f "$ncq" ]; then
+  # grep -c 는 0매칭 시 "0"을 찍고 exit 1 → `|| echo 0` 쓰면 "0\n0" 오염. `|| true`만.
+  nc_n=$(grep -cE '^- \[ \]' "$ncq" 2>/dev/null || true)
+  nc_n="${nc_n:-0}"; case "$nc_n" in ''|*[!0-9]*) nc_n=0 ;; esac
+  if [ "$nc_n" -gt 0 ]; then
+    msgs+=("확인 대기 항목 ${nc_n}건 (\`_workspace/needs-confirm.md\`) — 사람 판단 필요(동일성·상충 등). 확인 후 체크.")
+  fi
 fi
 
 if [ "${#msgs[@]}" -eq 0 ]; then

--- a/.claude/skills/wiki-ops/SKILL.md
+++ b/.claude/skills/wiki-ops/SKILL.md
@@ -71,6 +71,14 @@ raw/  →  L1-working  →  L2-episodic  →  L3-semantic  →  L4-procedural
 - 스톨·재시도 발생 시 낭비 토큰은 `wasted_tokens`에 별도 기록(효율 왜곡 방지).
 - 리포트: `python3 metrics/cost-report.py` — 페이지당·소스100줄당 토큰, 낭비율, 총계. v2 도입 효과를 이 지표로 추적한다.
 
+## 운영 규칙 (P2·P3 — v0.6)
+- **신뢰도 하드코딩 금지.** 인제스트·lint·병합 프롬프트에 confidence 숫자(0.85 등)를 지정하지 마라 — 언제나 `confidence.py` 결과가 정본. (과거 오케스트레이터가 0.85로 지시 → 스크립트가 verbal 페널티로 0.75 교정한 사례.)
+- **짧은 소스는 배치 인제스트.** 메일·데일리처럼 짧은 동종 소스가 여럿 pending이면 **한 번에 묶어** 인제스트(스킬로딩·concept-index·부기 고정비 상각). 소스당 개별 스폰은 짧을수록 페이지당 토큰이 폭증.
+- **인라인 인제스트도 원장 기록.** 오케스트레이터가 에이전트 없이 직접 처리한 인제스트(예: 데일리)도 `metrics/ingest-cost.csv`에 기록 — 측정 정합(누락 시 통계 왜곡).
+- **concept-index 필터.** 위키가 커지면 `concept-index.sh . <키워드…>`로 소스 주제 관련분만 봐서 카탈로그 덤프를 바운드.
+- **MoC 남발 억제 → cartographer.** 신규 MoC는 최소화(기존 우선). 주제 MoC가 12개 넘으면 SessionStack 알림 → `wiki-cartographer`로 그룹 재구성.
+- **미해결 항목은 확인 큐로.** 사람 판단이 필요한 것(동일성·상충 등)은 `_workspace/needs-confirm.md`에 `- [ ] <항목>`으로 적재 — SessionStart가 리마인드.
+
 ## 규약 정본
 페이지 명명·frontmatter·신뢰도·덮어쓰기·망각·관계는 `CLAUDE.md`가 정본. 모든 전문가가 따른다.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,3 +89,4 @@ Ebbinghaus: 보존율 R=exp(−Δt/S), `decay_class`가 S 결정(아키텍처 �
 | 2026-07-23 | 비용 원장 | metrics/ingest-cost.csv + cost-report.py + wiki-ops 배선 | v2 비용대비효과 측정 — 문서당 토큰·페이지·낭비율 추적(오케스트레이터가 <usage> 기록) |
 | 2026-07-23 | v2.1 인제스트 최적화 | wiki-ingest(lazy)·wiki-ingestor(sonnet)·concept-index.sh·wiki-consolidate(배치병합)·cost-report(모델가중) | 속도·토큰 개선 — ①sonnet 라우팅 ②no-scan(concept-index) ③lazy(병합·신뢰도·관계·승격을 lint 배치로 지연). 측정: 페이지당 실질비용 ~4.6x↓·지연 ~3x↓ |
 | 2026-07-27 | 하네스 개선 P1 | validate-pages.py(포맷 검증)·lint-due(BACKLOG)·wiki-status-check | 무성 오염 조기 차단(stray 태그 85+3파일 sweep) + 백로그 기반 lint 트리거(시간 아닌 인제스트 누적 기준) |
+| 2026-07-27 | 하네스 개선 P2·P3 | concept-index(필터)·wiki-status-check(MoC·needs-confirm)·wiki-ops/ingest/lint 규칙 | P2: 신뢰도 하드코딩 금지·짧은소스 배치·인라인 원장정합·concept-index 필터. P3: 고inbound 스텁 자동초안·미해결 확인 큐·MoC 남발 억제 |


### PR DESCRIPTION
LLM-wiki 하네스 v0.6. 회고 도출 P2·P3 배선.

## P2 — 비용·측정
- 신뢰도 하드코딩 금지 (confidence.py 정본)
- 짧은 소스 배치 인제스트 + 인라인 원장 기록
- concept-index 다중키워드 필터(grep -F) — 스케일 시 카탈로그 바운드

## P3 — 완결성
- 고inbound(≥3) 스텁 자동초안 제안
- 미해결 확인 큐(_workspace/needs-confirm.md) + SessionStart 리마인드
- MoC 남발 억제(신규 최소·12개+ cartographer 권고)

## 외부 감사
agy 2라운드: 2건 지적(grep -c 오염·BRE 특수문자) → 수정 → 재감사 VERDICT: CLEAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)