### PR TITLE
Release v0.8.1 — query 속도 최적화 (sonnet 라우팅 + 선택적 환류)

### DIFF
--- a/.claude/agents/wiki-synthesizer.md
+++ b/.claude/agents/wiki-synthesizer.md
@@ -2,7 +2,7 @@
 name: wiki-synthesizer
 description: Answers questions against the LLM wiki. Reads index.md + relevant MoCs to locate pages, reads them, synthesizes a cited answer, and offers to file good answers back into the wiki as new pages so explorations compound. Use for querying/asking the wiki, comparisons, or "이거 위키에 저장해줘".
 tools: Read, Write, Edit, Glob, Grep, Bash
-model: opus
+model: sonnet
 skills: [wiki-query, wiki-moc]
 ---
 

--- a/.claude/skills/wiki-ops/SKILL.md
+++ b/.claude/skills/wiki-ops/SKILL.md
@@ -45,7 +45,7 @@ raw/  →  L1-working  →  L2-episodic  →  L3-semantic  →  L4-procedural
 ## 오퍼레이션 흐름
 **Ingest:** 소스 확인 → `wiki-ingestor`(L2 증거 페이지 + L3 통합 + 신뢰도 + 덮어쓰기 + 관계) → 새 L3 페이지 MoC 편입 → index·log 확인 → **비용 기록**(아래) → 신뢰도·대체 포함 보고.
 
-**Query:** `wiki-synthesizer`(index→MoC→L3 탐색 → 신뢰도·최신성 반영 인용 답변) → 환류 가치면 파일링 → log.
+**Query:** `wiki-synthesizer`(index→MoC→L3 탐색 → 신뢰도·최신성 반영 인용 답변) → 환류 가치면 파일링 → log. **모델: 기본 sonnet**(빠름) — 깊은 비교·다소스 종합·분석만 spawn 시 `model: opus`로 override. 이미 정본 query 페이지가 있으면 재종합 말고 참조(선택적 환류).
 
 > **질의 라우팅 규칙 (인라인 우회 금지).** 위키 내용을 근거로 답하는 질문은 **원칙적으로 `wiki-synthesizer`에게 위임**한다. 오케스트레이터가 grep으로 직접 종합하지 마라 — 그러면 신뢰도 병기·환류·index→MoC 탐색이 빠진다.
 > - **인라인 직접 응답 허용(예외):** 위키 근거가 필요 없는 것 — 하네스 사용법·메타 질문, 방금 대화 맥락 확인, 단일 값 조회(예: "지금 pending 몇 개?"는 스크립트 1회).

--- a/.claude/skills/wiki-query/SKILL.md
+++ b/.claude/skills/wiki-query/SKILL.md
@@ -7,6 +7,8 @@ description: How to answer a question against the LLM wiki (v2) — locate pages
 
 위키에 근거 있게 답하고 좋은 답을 환류한다. v2는 **신뢰도·최신성**을 답에 반영한다.
 
+> **모델·속도(v0.8.1):** 질의는 추출·인용 위주라 `wiki-synthesizer` 기본 **sonnet**(빠름·저비용). 깊은 비교·다소스 종합·분석은 오케스트레이터가 spawn 시 **opus로 override**. 검색 자체(index/`search.py`)는 즉시(토큰0) — 느림의 원인은 모델·환류지 검색이 아니다.
+
 ## 절차
 
 1. **탐색.** `index.md` → 관련 `wiki/moc/{topic}-moc.md` → L3-semantic 페이지 순. 애매하면 `python3 .claude/skills/wiki-lint/scripts/search.py "<query>"`(L1–L4 전체 grep). 소스 원문 근거가 필요하면 L2-episodic도.
@@ -22,7 +24,10 @@ description: How to answer a question against the LLM wiki (v2) — locate pages
 
 5. **형식.** 기본 md, 비교면 표, (요청 시) Marp·차트.
 
-6. **환류.** 재사용 가치 있는 답(비교·분석·발견한 연결, **브리핑·보고·종합**)은 파일링 제안 — 특히 여러 소스를 엮은 답은 채팅으로 흘리지 말고 남긴다. 승인 시:
+6. **환류 (선택적 — 매번 하지 마라).** 파일링은 **재사용 가치가 확실할 때만** — 여러 소스를 엮은 종합·비교·분석·보고. 아래는 **환류하지 말고 참조/답변만**(spawn·파일쓰기 오버헤드 절약):
+   - **이미 정본 페이지가 있는 질문** — 기존 `query-*`/`concept-*`가 답을 담고 있으면 재작성 말고 그것을 참조(신 정보 있을 때만 갱신).
+   - **단순 조회·일회성** — 단일 사실 확인, "지금 상태 뭐야" 류.
+   재사용 가치 있는 답(비교·분석·발견한 연결, **브리핑·보고·종합**)만 파일링 제안. 승인 시:
    - **개념·사실**이면 `wiki/L3-semantic/`에 `type: concept`(또는 fact).
    - **브리핑·보고·상태 요약**처럼 시점 종속 답이면 `type: query`(예: `query-<주제>-YYYY-MM-DD.md`). **`type`은 query, 계층은 L2-episodic** — query는 "그 시점에 종합한 것"이라 본질이 일화(episodic)다(그래서 `decay_class: episodic`로 시간 지나면 바램). 계층=L2, 유형=query로 source/session과 구분한다.
    - 공통: sources·confidence·last_confirmed·decay_class 부여, 근거 페이지와 양방향 링크, 알맞은 MoC 편입, log append(`## [오늘] query | <요지>`).


### PR DESCRIPTION
## 개요
query 답변이 느린 문제(원인: wiki-synthesizer opus + 매번 환류) 최적화.

## 변경
- **① sonnet 라우팅** — wiki-synthesizer 기본 opus→sonnet. 깊은 비교·다소스 분석만 opus override.
- **② 선택적 환류** — 기존 정본 페이지가 답 담으면 참조, 단순 조회 생략, 재사용 가치 종합만 파일링.

## e2e 측정
동일 다소스 종합 질의: **~102~154초(opus) → 66초(sonnet), ~1.7배↑**. 인용·신뢰도 품질 동일, 선택적 환류 정확 작동.

## 외부 감사
agy: 일관성·환류 누락 위험 없음·품질 무충돌·opus override 실행가능 → **VERDICT: CLEAN**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)