### PR TITLE
fix: ingest-status 긴 frontmatter 스탬프 탐지 버그

### DIFF
--- a/.claude/skills/wiki-lint/scripts/ingest-status.py
+++ b/.claude/skills/wiki-lint/scripts/ingest-status.py
@@ -20,13 +20,39 @@ except Exception:
     pass
 
 
+def frontmatter(path):
+    """파일 맨 위 YAML frontmatter 블록(--- ... ---)만 반환. 없으면 "".
+
+    고정 바이트(read(600)) 대신 블록 전체를 읽는다 — 긴 description 등으로
+    스탬프 필드가 앞쪽 N바이트 밖에 있어도 놓치지 않기 위함. 본문은 안 읽는다
+    (닫는 --- 에서 멈춤). 방어적으로 최대 200줄까지만 스캔.
+    """
+    with open(path, encoding="utf-8-sig", errors="replace") as fh:
+        if fh.readline().strip() != "---":
+            return ""  # frontmatter 없음
+        out = []
+        for _ in range(200):
+            line = fh.readline()
+            if not line or line.strip() == "---":
+                # 닫는 --- 를 만났을 때만 정상 frontmatter로 인정.
+                # 파일 끝(닫힘 없음)이면 본문 오파싱 방지 위해 "" 반환.
+                return "".join(out) if line.strip() == "---" else ""
+            out.append(line)
+    return ""  # 200줄 내 닫는 --- 없음 → frontmatter 아님으로 간주
+
+
+# 값 앞뒤 따옴표(선택) 허용 — `ingest_status: "done"` / `ingested: '2026-07-31'` 대응.
+# ^ 앵커 유지: 스탬프는 항상 top-level 필드(중첩 아님)라 들여쓰기 매칭은 오탐만 늘림.
+_RE_STATUS = re.compile(r"""^ingest_status:\s*['"]?(\w+)""", re.MULTILINE)
+_RE_DATE = re.compile(r"""^ingested:\s*['"]?([0-9-]+)""", re.MULTILINE)
+
+
 def stamp(path):
     """(status, ingested_date). status in done|stale|pending."""
-    with open(path, encoding="utf-8-sig", errors="replace") as fh:
-        head = fh.read(600)
-    m = re.search(r"^ingest_status:\s*(\w+)", head, re.MULTILINE)
+    fm = frontmatter(path)
+    m = _RE_STATUS.search(fm)
     st = m.group(1) if m else "pending"
-    d = re.search(r"^ingested:\s*([0-9-]+)", head, re.MULTILINE)
+    d = _RE_DATE.search(fm)
     return st, (d.group(1) if d else "?")
 
 


### PR DESCRIPTION
read(600) 고정 → frontmatter 블록 전체 파싱. 긴 description으로 스탬프가 앞 600바이트 밖에 있으면 인제스트 완료 파일이 PENDING 오인되던 버그 수정. 외부감사(agy) 반영: 값 따옴표 허용 + 닫는 --- 없을 때 본문 오파싱 방지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)